### PR TITLE
Makefile updates

### DIFF
--- a/makefile
+++ b/makefile
@@ -5,19 +5,15 @@ REV=${shell [ -d .hg ] && hg id -n || git rev-parse --short HEAD}
 .PHONY:	em emwarn debug trace fixed
 
 em:	# normal
-	rm -rf em.o
 	$(CC) -DREV=\"${REV}\" -DNOTRACE -DFAST -O -Winline em.c -o em
 
 emwarn: # lots of compiler warnings
-	rm -rf em.o
 	$(CC) -DREV=\"${REV}\" -DNOTRACE -DFAST -O -Wall -Wextra -pedantic -Wconversion em.c -o em
 
 debug:   # gdb
-	rm -rf em.o
 	$(CC) -DREV=\"${REV}\" -DNOTRACE -DFAST -g -O0 em.c -o em
 
 trace:   # tracing
-	rm -rf em.o
 	$(CC) -DREV=\"${REV}\" -DFAST -O em.c -o em
 
 # the fixed clock rate build is useful for making problems reproduceable.
@@ -27,5 +23,7 @@ trace:   # tracing
 # failure, then enable tracing a little before that with -trace <IC - 100>
 
 fixed:  # fixed clock rate
-	rm -rf em.o
 	$(CC) -DREV=\"${REV}\" -DFIXEDCLOCK -DNOIDLE -DFAST -O em.c -o em
+
+clean:
+	rm -f em.o em

--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@
 
 REV=${shell [ -d .hg ] && hg id -n || git rev-parse --short HEAD}
 
-.PHONY:	em emwarn debug trace fixed
+.PHONY:	emwarn debug trace fixed
 
 em:	# normal
 	$(CC) -DREV=\"${REV}\" -DNOTRACE -DFAST -O -Winline em.c -o em

--- a/makefile
+++ b/makefile
@@ -2,18 +2,27 @@
 
 REV=${shell [ -d .hg ] && hg id -n || git rev-parse --short HEAD}
 
+em_objs = em.o em
+em_deps = \
+  em.c regs.h emdev.h ea64v.h ea32i.h fp.h dispatch.h geom.h \
+  devpnc.h devamlc.h swap.h
+
 .PHONY:	emwarn debug trace fixed
 
-em:	# normal
+# normal
+em: $(em_deps)
 	$(CC) -DREV=\"${REV}\" -DNOTRACE -DFAST -O -Winline em.c -o em
 
-emwarn: # lots of compiler warnings
+# lots of compiler warnings
+emwarn: $(em_deps)
 	$(CC) -DREV=\"${REV}\" -DNOTRACE -DFAST -O -Wall -Wextra -pedantic -Wconversion em.c -o em
 
-debug:   # gdb
+# gdb
+debug: $(em_deps)
 	$(CC) -DREV=\"${REV}\" -DNOTRACE -DFAST -g -O0 em.c -o em
 
-trace:   # tracing
+# tracing
+trace: $(em_deps)
 	$(CC) -DREV=\"${REV}\" -DFAST -O em.c -o em
 
 # the fixed clock rate build is useful for making problems reproduceable.
@@ -22,8 +31,9 @@ trace:   # tracing
 # PRIMOS.COMI to get a more consistent instruction count for the
 # failure, then enable tracing a little before that with -trace <IC - 100>
 
-fixed:  # fixed clock rate
+# fixed clock rate
+fixed: $(em_deps)
 	$(CC) -DREV=\"${REV}\" -DFIXEDCLOCK -DNOIDLE -DFAST -O em.c -o em
 
 clean:
-	rm -f em.o em
+	rm -f $(em_objs)

--- a/makefile
+++ b/makefile
@@ -6,19 +6,19 @@ REV=${shell [ -d .hg ] && hg id -n || git rev-parse --short HEAD}
 
 em:	# normal
 	rm -rf em.o
-	cc -DREV=\"${REV}\" -DNOTRACE -DFAST -O -Winline em.c -o em
+	$(CC) -DREV=\"${REV}\" -DNOTRACE -DFAST -O -Winline em.c -o em
 
 emwarn: # lots of compiler warnings
 	rm -rf em.o
-	cc -DREV=\"${REV}\" -DNOTRACE -DFAST -O -Wall -Wextra -pedantic -Wconversion em.c -o em
+	$(CC) -DREV=\"${REV}\" -DNOTRACE -DFAST -O -Wall -Wextra -pedantic -Wconversion em.c -o em
 
 debug:   # gdb
 	rm -rf em.o
-	cc -DREV=\"${REV}\" -DNOTRACE -DFAST -g -O0 em.c -o em
+	$(CC) -DREV=\"${REV}\" -DNOTRACE -DFAST -g -O0 em.c -o em
 
 trace:   # tracing
 	rm -rf em.o
-	cc -DREV=\"${REV}\" -DFAST -O em.c -o em
+	$(CC) -DREV=\"${REV}\" -DFAST -O em.c -o em
 
 # the fixed clock rate build is useful for making problems reproduceable.
 #
@@ -28,4 +28,4 @@ trace:   # tracing
 
 fixed:  # fixed clock rate
 	rm -rf em.o
-	cc -DREV=\"${REV}\" -DFIXEDCLOCK -DNOIDLE -DFAST -O em.c -o em
+	$(CC) -DREV=\"${REV}\" -DFIXEDCLOCK -DNOIDLE -DFAST -O em.c -o em


### PR DESCRIPTION
These changes allow swapping C compiler, conditional rebuilds of the emulator, and add a 'clean' target.